### PR TITLE
Scala2.12.1 + script templates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 		<license.copyrightOwners>Board of Regents of the University of
 Wisconsin-Madison.</license.copyrightOwners>
 
-		<scala.version>2.12.0</scala.version>
+		<scala.version>2.12.1</scala.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/scijava/plugins/scripting/scala/ScalaScriptEngine.java
+++ b/src/main/java/org/scijava/plugins/scripting/scala/ScalaScriptEngine.java
@@ -1,0 +1,71 @@
+/*
+ * #%L
+ * JSR-223-compliant Scala scripting language plugin.
+ * %%
+ * Copyright (C) 2013 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.plugins.scripting.scala;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+
+import org.scijava.script.AdaptedScriptEngine;
+
+/**
+ * Scala interpreter
+ *
+ * @author Keith Schulze
+ * @see ScriptEngine
+ */
+public class ScalaScriptEngine extends AdaptedScriptEngine {
+
+    public ScalaScriptEngine(ScriptEngine engine) {
+        super(engine);
+    }
+
+    @Override
+    public Object get(String key) {
+        // First try to get value from bindings
+        Object value = super.get(key);
+
+        // NB: Extracting values from Scala Script Engine are a little tricky.
+        // Values (variables) initialised or computed in the script are
+        // not added to the bindings of the CompiledScript AFAICT. Therefore
+        // the only way to extract them is to evaluate the variable and
+        // capture the return. If it evaluates to null or throws a
+        // a ScriptException, we simply return null.
+        if (value == null) try {
+            value = super.eval(key);
+        } catch (ScriptException ignored) {
+            // HACK: Explicitly ignore ScriptException, which arises if
+            // key is not found. This feels bad because it fails silently
+            // for the user, but it mimics behaviour in other script langs.
+        }
+
+        return value;
+    }
+}

--- a/src/main/java/org/scijava/plugins/scripting/scala/ScalaScriptLanguage.java
+++ b/src/main/java/org/scijava/plugins/scripting/scala/ScalaScriptLanguage.java
@@ -70,8 +70,10 @@ public class ScalaScriptLanguage extends AdaptedScriptLanguage {
 		final Settings settings = new Settings();
 		settings.classpath().value_$eq(getClasspath());
 
-		return Scripted.apply(new Scripted.Factory(), settings,
-			new NewLinePrintWriter(new ConsoleWriter(), true));
+		Scripted eng = Scripted.apply(new Scripted.Factory(), settings,
+				new NewLinePrintWriter(new ConsoleWriter(), true));
+
+		return new ScalaScriptEngine(eng);
 	}
 
 	/** Retrieves the current classpath as a string. */

--- a/src/main/resources/script_templates/Examples/Blur_Image.scala
+++ b/src/main/resources/script_templates/Examples/Blur_Image.scala
@@ -1,0 +1,26 @@
+// @Dataset inputImg
+// @OpService ops
+// @OUTPUT Dataset(label="Blurred") blurredImg
+
+// A simple Scala script that blurs an input image with
+// a Gaussian filter. Note that you must have an image
+// open to run this script.
+// It is the duty of the scripting framework to bind
+// the input image and then display the blurred output
+// image. It also binds the ImageJ OpService for filtering.
+
+import net.imagej.ops.OpService
+import net.imglib2.img.Img
+import net.imglib2.`type`.numeric.RealType
+
+// Scala is a compiled language with a very strict/powerful
+// type system. We need to cast any parameters that are bound
+// at runtime to their known type otherwise the Scala compiler
+// will throw Type errors.
+
+// Dataset extends Img[RealType[_]]. We cast directly to
+// Img[RealType[_]] to narrow the underlying pixel type,
+// which is required for the Gauss filter.
+val img = inputImg.asInstanceOf[Img[T] forSome {type T <: RealType[T]}]
+
+val blurredImg = ops.asInstanceOf[OpService].filter().gauss(img, 2)

--- a/src/main/resources/script_templates/Intro/Greeting.scala
+++ b/src/main/resources/script_templates/Intro/Greeting.scala
@@ -1,0 +1,9 @@
+// @String(label="Please enter your name",description="Name field") name
+// @OUTPUT String greeting
+
+// A Scala script with parameters
+// It is the duty of the scripting framework to harvest
+// the 'name' parameter from the user, and then display
+// the 'greeting' output parameter, based on it's type.
+
+val greeting = s"Hello, ${name}!"

--- a/src/main/resources/script_templates/Intro/Hello_World.scala
+++ b/src/main/resources/script_templates/Intro/Hello_World.scala
@@ -1,0 +1,5 @@
+// A very simple Scala script.
+// It is the duty of the scripting framework to display
+// the script's return value, based on its type.
+
+"Hello, World!"

--- a/src/test/java/org/scijava/plugins/scripting/scala/ScalaTest.java
+++ b/src/test/java/org/scijava/plugins/scripting/scala/ScalaTest.java
@@ -44,8 +44,9 @@ import org.scijava.script.ScriptService;
 
 /**
  * Scala unit tests.
- * 
+ *
  * @author Johannes Schindelin
+ * @author Keith Schulze
  */
 public class ScalaTest {
 


### PR DESCRIPTION
Updates to Scala 2.12.1.

Also adds script templates as discussed in #3. Extracting values from Scala script engine was somewhat tricky as values/variables initialised or computed in the script are not added to the script engine bindings. The only way I found to extract these was to eval the variable and capture the result.