### PR TITLE
Scala 2.12.4 upgrade + improve input type resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 		<license.copyrightOwners>Board of Regents of the University of
 Wisconsin-Madison.</license.copyrightOwners>
 
-		<scala.version>2.12.1</scala.version>
+		<scala.version>2.12.4</scala.version>
 
 		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
 		<releaseProfiles>deploy-to-imagej</releaseProfiles>

--- a/src/test/java/org/scijava/plugins/scripting/scala/ScalaTest.java
+++ b/src/test/java/org/scijava/plugins/scripting/scala/ScalaTest.java
@@ -7,13 +7,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -33,13 +33,17 @@ package org.scijava.plugins.scripting.scala;
 import static org.junit.Assert.assertEquals;
 
 import java.io.StringWriter;
+import java.util.concurrent.ExecutionException;
 
 import javax.script.ScriptEngine;
+import javax.script.ScriptException;
 import javax.script.SimpleScriptContext;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.scijava.Context;
 import org.scijava.script.ScriptLanguage;
+import org.scijava.script.ScriptModule;
 import org.scijava.script.ScriptService;
 
 /**
@@ -50,14 +54,24 @@ import org.scijava.script.ScriptService;
  */
 public class ScalaTest {
 
-	@Test
-	public void testBasic() throws Exception {
+	private ScriptService scriptService;
+	private ScriptEngine engine;
+
+	@Before
+	public void setUp() {
 		final Context context = new Context(ScriptService.class);
-		final ScriptService scriptService = context.getService(ScriptService.class);
+		scriptService = context.getService(ScriptService.class);
 
 		final ScriptLanguage language =
 			scriptService.getLanguageByExtension("scala");
-		final ScriptEngine engine = language.getScriptEngine();
+		engine = language.getScriptEngine();
+	}
+
+	/**
+	 * Test whether we can evaluate something in the ScalaScriptEngine.
+	 */
+	@Test
+	public void testBasic() throws Exception {
 
 		final SimpleScriptContext ssc = new SimpleScriptContext();
 		final StringWriter writer = new StringWriter();
@@ -66,5 +80,52 @@ public class ScalaTest {
 		final String script = "print(\"3\");";
 		engine.eval(script, ssc);
 		assertEquals("3", writer.toString());
+	}
+
+	/**
+	 * Test whether input parameters resolve to the correct type.
+	 */
+	@Test
+	public void testParameterType() throws ScriptException, ExecutionException, InterruptedException {
+
+		String ls = System.getProperty("line.separator");
+		// We create a script that requests injection of a @ScriptService
+		// via a Script parameter. Then use Scala reflection tools to check
+		// the runtime TypeTag of the ScriptService. We expect this to return
+		// org.scijava.script.ScriptService rather than Object.
+		final String script = String.join(
+			ls,
+			"// @ScriptService ss",
+			"// @OUTPUT String ssType",
+			"import scala.reflect.runtime.{universe => ru}",
+			"def getTypeTag[T: ru.TypeTag](v: T) = ru.typeTag[T]",
+			"val ssType: String = getTypeTag(ss).toString"
+		);
+
+		final ScriptModule sm = scriptService.run("test.scala", script, true).get();
+
+		final Object actual = sm.getOutput("ssType");
+		final String expected = "TypeTag[org.scijava.script.ScriptService]";
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testParameters() throws ScriptException, ExecutionException, InterruptedException {
+
+		String ls = System.getProperty("line.separator");
+		final String script = String.join(
+			ls,
+			"// @ScriptService ss",
+			"// @OUTPUT String lang",
+			"val lang = ss.getLanguageByName(\"scala\").getLanguageName()"
+		);
+
+		final ScriptModule sm = scriptService.run("test.scala", script, true).get();
+
+		final Object actual = sm.getOutput("lang");
+		final String expected = scriptService.getLanguageByName("scala").getLanguageName();
+
+		assertEquals(expected, actual);
 	}
 }


### PR DESCRIPTION
Upgrades Scala to latest stable version.
 
Also, automatically cast input parameters to correct type to reduce boilerplate on developers. Previously, running the following with blob.gif open would give a ScriptException:
```scala
// @Dataset img
println(s"Img has ${img.getChannels} channel/channels")

// output: javax.script.ScriptException: value getChannels is not a member of Object 
// in println(s"Img has ${img.getChannels} channel/s")
```
This is because input parameters are injected into the script Bindings (i.e., Map<String, Object>), where type information is lost. This could be fixed by explicitly casting img to Dataset e.g., `img.asInstanceOf[Dataset].getChannels`. After this change, this is no longer necessary since we cast for input parameters to correct type automatically (i.e., through callback in ScriptModule). So, the following works:

```scala
// @Dataset img
println(s"Img has ${img.getChannels} channel/channels")

// output: Img has 1 channel/channels
```

